### PR TITLE
feat: blacklist based on urlmap

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,6 +74,14 @@
   revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
   version = "v1.2.0"
 
+[[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -81,6 +89,7 @@
     "golang.org/x/oauth2/google",
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/googleapi",
+    "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Google load balancer project.
 | GOOGLE_PROJECT   | Google Project _ID_  to manage HTTPSProxies for |
 | GOOGLE_APPLICATION_CREDENTIALS | Path to Google Auth file. More info [here](https://cloud.google.com/docs/authentication/getting-started) |
 
+| YAML Property | Function |
+| --------- | --------- |
+| ignoreProxies[] | If an HTTPSProxy uses a URLMap within this list the SSLPolicy will not be asserted |
+
 ## IAM Permissions
 
 ```

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
 	sslpolicy "github.com/commercetools/gcp-ssl-policy-asserter/pkg"
 	"golang.org/x/oauth2/google"
@@ -10,6 +11,16 @@ import (
 )
 
 func main() {
+	var confPath string
+	if len(os.Args) > 1 {
+		confPath = os.Args[1]
+	}
+	config, err := sslpolicy.LoadConfig(confPath)
+
+	if err != nil {
+		log.Fatalf("Could not read config %s: %v", confPath, err)
+	}
+
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, compute.ComputeScope)
 
@@ -20,31 +31,36 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	project := sslpolicy.Project()
-	if project == "" {
+	if config.Project() == "" {
 		log.Fatalf("GOOGLE_PROJECT environment variable not set.")
 	}
 
-	sslPolicy, err := sslpolicy.AssertPolicy(project, svc)
+	sslPolicy, err := sslpolicy.AssertPolicy(config, svc)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	prxySvc := compute.NewTargetHttpsProxiesService(svc)
-	listCall := prxySvc.List(project)
+	listCall := prxySvc.List(config.Project())
 	prxyList, err := listCall.Do()
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("Found %d HttpsProxies in %s project", len(prxyList.Items), project)
+	for k := range config.IgnoreProxies {
+		log.Printf("Ignoring HTTPSTargetProxies using URLMap %s", k)
+	}
+	prxyList = sslpolicy.SelectProxies(prxyList, config.IgnoreProxies)
+	log.Printf("Found %d HttpsProxies in %s project", len(prxyList.Items), config.Project())
+
 	sslPolicyReference := compute.SslPolicyReference{
 		SslPolicy: sslPolicy.SelfLink,
 	}
+
 	for _, prxy := range prxyList.Items {
 		if prxy.SslPolicy != sslPolicy.SelfLink {
-			setPolicyCall := prxySvc.SetSslPolicy(project, prxy.Name, &sslPolicyReference)
+			setPolicyCall := prxySvc.SetSslPolicy(config.Project(), prxy.Name, &sslPolicyReference)
 			_, err := setPolicyCall.Do()
 			if err != nil {
 				log.Printf("WARNING: %s HttpsProxy errored: %v", prxy.Name, err)
@@ -52,7 +68,5 @@ func main() {
 				log.Printf("%s SSLPolicy set to %s \n", prxy.Name, sslPolicy.SelfLink)
 			}
 		}
-
 	}
-
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -4,18 +4,70 @@ package sslpolicy
 * This file should contain all of the functions that
 * return configuration values.
  */
-import "os"
+import (
+	"io/ioutil"
+	"os"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// config defines the structure of the YAML file
+// that should be unmarshalled from disk.
+type config struct {
+	IgnoreProxies []string `yaml:"ignoreProxies,omitempty"`
+}
+
+// Config contains the configuration values that the rest of
+// the program will leverage.
+// Fields from the YAML are manipulated to become more convenient
+// for the internal program.
+type Config struct {
+	IgnoreProxies map[string]struct{}
+}
 
 // PolicyName will be used by the service to fetch the current TLS Policy
 // by this name and if not found will create it.
 // The Version string at the end is very important! It will be used
 // to upgrade TLS policies in the future.
-func PolicyName() string {
+func (*Config) PolicyName() string {
 	return os.Getenv("SSL_POLICY_NAME")
 }
 
 // Project returns the ID (not the display name) of the Google Cloud
 // Project to work under.
-func Project() string {
+func (*Config) Project() string {
 	return os.Getenv("GOOGLE_PROJECT")
+}
+
+// listToContainsMap converts a list of strings
+// into a map that will be used for "contains" checking.
+func listToContainsMap(x []string) (result map[string]struct{}) {
+	result = make(map[string]struct{})
+	var empty struct{}
+	for _, v := range x {
+		result[v] = empty
+	}
+	return result
+}
+
+// LoadConfig returns an instance of the
+// unmarshalled configuration file.
+func LoadConfig(path string) (*Config, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path != "" {
+		data, err = ioutil.ReadFile(path)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+	var rawConfig config
+	var result Config
+	yaml.Unmarshal(data, &rawConfig)
+	result.IgnoreProxies = listToContainsMap(rawConfig.IgnoreProxies)
+
+	return &result, err
 }

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -1,0 +1,30 @@
+package sslpolicy
+
+import "testing"
+
+// TestListToContainsMap validates listToContainsMap
+// creates a map for "does contain checking" from a list of
+// strings correctly.
+func TestListToContainsMap(t *testing.T) {
+	input := []string{"cat", "dog", "potato"}
+	output := listToContainsMap(input)
+
+	for _, v := range input {
+		_, ok := output[v]
+		if !ok {
+			t.Fatalf("output did not contain %s", v)
+		}
+	}
+}
+
+func TestEmptyListToContainsMap(t *testing.T) {
+	input := []string{}
+	output := listToContainsMap(input)
+
+	for _, v := range []string{"x", "y", "z"} {
+		_, ok := output[v]
+		if ok {
+			t.Fatalf("output should not contain %s.", v)
+		}
+	}
+}

--- a/pkg/proxies.go
+++ b/pkg/proxies.go
@@ -1,0 +1,23 @@
+package sslpolicy
+
+import (
+	"strings"
+
+	compute "google.golang.org/api/compute/v1"
+)
+
+// SelectProxies removes black listed proxies from our list of
+// targets.
+func SelectProxies(proxies *compute.TargetHttpsProxyList, blacklist map[string]struct{}) *compute.TargetHttpsProxyList {
+	var tmp []*compute.TargetHttpsProxy
+	for _, proxy := range proxies.Items {
+		splitURLMapURL := strings.Split(proxy.UrlMap, "/")
+		urlMapName := splitURLMapURL[len(splitURLMapURL)-1]
+		_, ok := blacklist[urlMapName]
+		if !ok {
+			tmp = append(tmp, proxy)
+		}
+	}
+	proxies.Items = tmp
+	return proxies
+}

--- a/pkg/proxies_test.go
+++ b/pkg/proxies_test.go
@@ -1,0 +1,64 @@
+package sslpolicy
+
+import (
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+)
+
+// TestSelectProxies verifies that
+// SelectProxies properly removes blacklisted items
+// and keeps all other items.
+func TestSelectProxies(t *testing.T) {
+	proxyList := compute.TargetHttpsProxyList{
+		Items: []*compute.TargetHttpsProxy{
+			{
+				Name:   "keep1",
+				UrlMap: "https://www.googleapis.compute/v1/projects/project/global/urlMaps/keeper",
+			},
+			{
+				Name:   "remove1",
+				UrlMap: "projects/project/global/urlMaps/loser",
+			},
+			{
+				Name:   "keep2",
+				UrlMap: "global/urlMaps/keeper",
+			},
+			{
+				Name:   "remove2",
+				UrlMap: "global/urlMaps/anotherLoser",
+			},
+		},
+	}
+
+	blacklist := map[string]struct{}{
+		"loser":        {},
+		"anotherLoser": {},
+	}
+
+	expectedBlackList := map[string]struct{}{
+		"remove1": {},
+		"remove2": {},
+	}
+	expected := map[string]struct{}{
+		"keep1": {},
+		"keep2": {},
+	}
+
+	output := SelectProxies(&proxyList, blacklist)
+
+	for _, v := range output.Items {
+
+		_, ok := expectedBlackList[v.Name]
+		if ok {
+			t.Fatalf("expected not to find %s", v.Name)
+		}
+	}
+
+	for _, v := range output.Items {
+		_, ok := expected[v.Name]
+		if !ok {
+			t.Fatalf("missing %s", v.Name)
+		}
+	}
+}


### PR DESCRIPTION
This adds the ability to leverage a configuration file and blacklisting rules based off of what the Google Cloud UI calls "LoadBalancers", but are actually "URLMaps".